### PR TITLE
Fix taglist sorted logic

### DIFF
--- a/src/components/PostTags/index.jsx
+++ b/src/components/PostTags/index.jsx
@@ -1,24 +1,33 @@
-import React, { Component } from "react";
-import _ from "lodash";
-import { Link } from "gatsby";
-import Chip from "react-md/lib/Chips";
-import "./PostTags.scss";
+import React, {Component} from 'react';
+import _ from 'lodash';
+import {Link} from 'gatsby';
+import Chip from 'react-md/lib/Chips';
+import './PostTags.scss';
 
 class PostTags extends Component {
-  render() {
-    const { tags } = this.props;
+  getTagList (tags) {
+    const tagList = [];
+    tags.sort ((a, b) => (a < b ? -1 : 1));
+
+    tags.forEach (tag => {
+      tagList.push (
+        <Link
+          key={tag}
+          style={{textDecoration: 'none'}}
+          to={`/tags/${_.kebabCase (tag)}`}
+        >
+          <Chip label={tag} className="post-preview-tags" />
+        </Link>
+      );
+    });
+    return tagList;
+  }
+  render () {
+    const {tags} = this.props;
+    const tagList = this.getTagList (tags);
     return (
       <div className="post-tag-container">
-        {tags &&
-          tags.map(tag => (
-            <Link
-              key={tag}
-              style={{ textDecoration: "none" }}
-              to={`/tags/${_.kebabCase(tag)}`}
-            >
-              <Chip label={tag} className="post-preview-tags" />
-            </Link>
-          ))}
+        {tagList && tagList}
       </div>
     );
   }


### PR DESCRIPTION
【修正】タグ一覧の順序を統一するロジックを実装 #204 のプルリク